### PR TITLE
Fixed order of operations error in PR #2 for unit inconsistency

### DIFF
--- a/functions/fm2d.m
+++ b/functions/fm2d.m
@@ -309,11 +309,7 @@ elseif ((d<0) && (order==1))
 	if (ox==0)
 		xmin1 = Inf;
 	end
-	if (xmin1 < ymin1)
-		time = xmin1 + dx / Fij;
-	else
-		time = ylim1 + dy / Fij;
-	end
+	time = min(xmin1 + dx / Fij, ymin1 + dy / Fij);
 	eFlag = 2;
 else
 	% All good.

--- a/functions/fm2dc.cpp
+++ b/functions/fm2dc.cpp
@@ -349,10 +349,7 @@ double calcTime(int i, int j, double Fij, double *T, bool *Frozen,
 						xmin1=Inf;
 
 				*eFlag = 2;
-				if (xmin1 < ymin1)
-					time = xmin1 + dx / Fij;
-				else
-					time = ymin1 + dy / Fij;
+				time = MIN(xmin1 + dx / Fij, ymin1 + dy / Fij);
 		}
 		else{
 				*eFlag = 0;

--- a/functions/fm3d.m
+++ b/functions/fm3d.m
@@ -246,13 +246,7 @@ elseif ((d<0) && (order==1))
 	if (oz==0)
 		zmin1 = Inf;
 	end
-	if (xmin1 < ymin1 && xmin1 < zmin1)
-		time = xmin1 + dx / Fijk;
-	elseif (ymin1 < zmin1)
-		time = ymin1 + dy / Fijk;
-	else
-		time = zmin1 + dz / Fijk;
-	end
+	time = min([(xmin1 + dx / Fijk) (ymin1 + dy/Fijk) (zmin1 + dz/Fijk)]);
 	eFlag = 2;
 else
 	% Solve quadratic equation. Only use the maximum root.

--- a/functions/fm3dc.cpp
+++ b/functions/fm3dc.cpp
@@ -406,12 +406,7 @@ double calcTime(int i, int j, int k, double Fijk, double *T, bool *Frozen,
 						zmin1=Inf;
 
 				*eFlag = 2;
-				if (xmin1 < ymin1 && xmin1 < zmin1)
-					time = xmin1 + dx / Fijk;
-				else if (ymin1 < zmin1)
-					time = ymin1 + dy / Fijk;
-				else
-					time = zmin1 + dz / Fijk;
+				time = MIN(MIN(xmin1 + dx / Fijk, zmin1 + dz / Fijk), ymin1 + dy / Fijk);
 		}
 		else{
 				*eFlag = 0;


### PR DESCRIPTION
The min() operation needs to be applied after the addition of the edge costs, not before, to account for the potentially significant difference in edge lengths on non-square grids. As a side effect the code looks much more like the original code before the fix was applied.